### PR TITLE
[T230] Add method to search for a movie by title and optionally year

### DIFF
--- a/src/Domain/Model/Movie/MovieRepository.php
+++ b/src/Domain/Model/Movie/MovieRepository.php
@@ -6,4 +6,5 @@ interface MovieRepository
 {
     public function manyWithTitleLike($title);
     public function oneOfId($id);
+    public function oneOfTitle($title, $year = null);
 }

--- a/src/Infrastructure/Persistence/OMDB/MovieRepository.php
+++ b/src/Infrastructure/Persistence/OMDB/MovieRepository.php
@@ -21,14 +21,31 @@ class MovieRepository implements Movie\MovieRepository
 
     public function oneOfId($id)
     {
-        $movie = new Movie\Movie($id);
+        return $this->oneOf(['i' => $id]);
+    }
 
-        $result = $this->adapter->get('', ['i' => $id, 'r' => 'json']);
+    public function oneOfTitle($title, $year = null)
+    {
+        $params = ['t' => $title];
+
+        if ($year) {
+            $params['y'] = $year;
+        }
+
+        return $this->oneOf($params);
+    }
+
+    private function oneOf(array $params)
+    {
+        $params = array_merge($params, ['r' => 'json']);
+
+        $result = $this->adapter->get('', $params);
 
         if ($result['Response'] == 'False') {
             throw new NotFoundException('No movie was found.');
         }
 
+        $movie = new Movie\Movie($result['imdbID']);
         $movie->populate(
             $result['Plot'],
             $result['Poster'] == 'N/A' ? null : $result['Poster'],

--- a/tests/unit/Infrastructure/Persistence/OMDB/MovieRepositoryTest.php
+++ b/tests/unit/Infrastructure/Persistence/OMDB/MovieRepositoryTest.php
@@ -48,6 +48,7 @@ class MovieRepositoryTest extends PHPUnit_Framework_TestCase
             'Poster' => 'N/A',
             'Type' => 'movie',
             'Year' => 2012,
+            'imdbID' => 15,
         ];
 
         $expected = [
@@ -79,6 +80,7 @@ class MovieRepositoryTest extends PHPUnit_Framework_TestCase
             'Poster' => 'my poster',
             'Type' => 'movie',
             'Year' => 2012,
+            'imdbID' => 15,
         ];
 
         $expected = [
@@ -95,6 +97,112 @@ class MovieRepositoryTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($response));
 
         $movie = $this->repository->oneOfId(15);
+
+        $this->assertNotNull($movie);
+        $this->assertInstanceOf(Movie\Movie::Class, $movie);
+        $this->assertEquals($expected, $movie->provideMovieInterest());
+    }
+
+    public function testOneOfTitleWithNoMatch()
+    {
+        $this->setExpectedException(NotFoundException::class);
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(['Response' => 'False']));
+        $this->repository->oneOfTitle(1234);
+    }
+
+    public function testOneOfTitleWithNoPoster()
+    {
+        $response = [
+            'Response' => 'True',
+            'Title' => 'Guardians of the Galaxy',
+            'Plot' => 'Superheros save the world',
+            'Poster' => 'N/A',
+            'Type' => 'movie',
+            'Year' => 2012,
+            'imdbID' => 15,
+        ];
+
+        $expected = [
+            'id' => 15,
+            'plot' => 'Superheros save the world',
+            'poster' => null,
+            'title' => 'Guardians of the Galaxy',
+            'type' => 'movie',
+            'year' => 2012,
+        ];
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($response));
+
+        $movie = $this->repository->oneOfTitle(15);
+
+        $this->assertNotNull($movie);
+        $this->assertInstanceOf(Movie\Movie::Class, $movie);
+        $this->assertEquals($expected, $movie->provideMovieInterest());
+    }
+
+    public function testOneOfTitleWithPoster()
+    {
+        $response = [
+            'Response' => 'True',
+            'Title' => 'Guardians of the Galaxy',
+            'Plot' => 'Superheros save the world',
+            'Poster' => 'my poster',
+            'Type' => 'movie',
+            'Year' => 2012,
+            'imdbID' => 15,
+        ];
+
+        $expected = [
+            'id' => 15,
+            'plot' => 'Superheros save the world',
+            'poster' => 'my poster',
+            'title' => 'Guardians of the Galaxy',
+            'type' => 'movie',
+            'year' => 2012,
+        ];
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($response));
+
+        $movie = $this->repository->oneOfTitle(15);
+
+        $this->assertNotNull($movie);
+        $this->assertInstanceOf(Movie\Movie::Class, $movie);
+        $this->assertEquals($expected, $movie->provideMovieInterest());
+    }
+
+    public function testOneOfTitleWithYear()
+    {
+        $response = [
+            'Response' => 'True',
+            'Title' => 'Guardians of the Galaxy',
+            'Plot' => 'Superheros save the world',
+            'Poster' => 'my poster',
+            'Type' => 'movie',
+            'Year' => 2012,
+            'imdbID' => 15,
+        ];
+
+        $expected = [
+            'id' => 15,
+            'plot' => 'Superheros save the world',
+            'poster' => 'my poster',
+            'title' => 'Guardians of the Galaxy',
+            'type' => 'movie',
+            'year' => 2012,
+        ];
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($response));
+
+        $movie = $this->repository->oneOfTitle(15, 2012);
 
         $this->assertNotNull($movie);
         $this->assertInstanceOf(Movie\Movie::Class, $movie);


### PR DESCRIPTION
The omdb api will return a match based on title. However, if there is more than one movie with a given name, it's not clear which one was returned. Passing the year along should eliminate most of those cases.
