### PR TITLE
[T232] Add domain service to remove unique movies

### DIFF
--- a/src/Domain/Model/Movie/RemoveDuplicateMoviesService.php
+++ b/src/Domain/Model/Movie/RemoveDuplicateMoviesService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Fusani\Movies\Domain\Model\Movie;
+
+class RemoveDuplicateMoviesService
+{
+    /**
+     * This function is necessary because the omdb api has entries with
+     * duplicate information but different imdb id's. I did not want to impose
+     * removing the duplicates on the repository so this is a domain service
+     * added for users to use or they can implement their own.
+     *
+     * @param array $movies : the movies to remove duplicates from
+     * @return array of unique movies
+     */
+    public function removeDuplicates(array $movies)
+    {
+        $uniqueMovies = [];
+
+        foreach ($movies as $movie) {
+            $interest = $movie->provideMovieInterest();
+
+            // here, uniqueness is defined by having the same title and year
+            // collisions simply overwrite the previous value but that shouldn't matter
+            $uniqueMovies[$interest['title'].$interest['year']] = $movie;
+        }
+
+        return array_values($uniqueMovies);
+    }
+}

--- a/tests/unit/Domain/Model/Movie/RemoveDuplicateMoviesServiceTest.php
+++ b/tests/unit/Domain/Model/Movie/RemoveDuplicateMoviesServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Fusani\Movies\Domain\Model\Movie;
+
+use PHPUnit_Framework_TestCase;
+
+class RemoveDuplicateMoviesServiceTest extends PHPUnit_Framework_TestCase
+{
+    protected $service;
+
+    public function setup()
+    {
+        $this->service = new RemoveDuplicateMoviesService();
+    }
+
+    public function testRemoveDuplicatesEmptyArrayStaysEmpty()
+    {
+        $uniqueMovies = $this->service->removeDuplicates([]);
+        $this->assertEquals([], $uniqueMovies);
+    }
+
+    public function testRemoveDuplicatesWithUniqueArrayStaysTheSame()
+    {
+        $movies = [
+            new Movie(1, 'Guardians of the Galaxy', 'movie', 2014),
+            new Movie(2, 'Ghostbusters', 'movie', 1984),
+            new Movie(3, 'Road House', 'movie', 1989),
+        ];
+
+        $uniqueMovies = $this->service->removeDuplicates($movies);
+
+        $this->assertEquals($uniqueMovies, $movies);
+    }
+
+    public function testRemoveDuplicatesRemovesDuplicates()
+    {
+        $movies = [
+            new Movie(1, 'Guardians of the Galaxy', 'movie', 2014),
+            new Movie(2, 'Ghostbusters', 'movie', 1984),
+            new Movie(3, 'Road House', 'movie', 1989),
+            new Movie(4, 'Guardians of the Galaxy', 'movie', 2014),
+            new Movie(5, 'Road House', 'movie', 1989),
+        ];
+
+        $uniqueMovies = $this->service->removeDuplicates($movies);
+        $expected = [
+            $movies[3], $movies[1], $movies[4],
+        ];
+
+        $this->assertEquals($expected, $uniqueMovies);
+    }
+}


### PR DESCRIPTION
The OMDB api will return what are essentially duplicate movies. They have the same title and year but different imdb ids. However, we don't care that they are different ids.
